### PR TITLE
replace unicode with ascii in csv dumps

### DIFF
--- a/ocemr/views/reports.py
+++ b/ocemr/views/reports.py
@@ -67,7 +67,10 @@ def dump_csv(filename,field_names,headers,data_rows):
                 row=[]
                 for field in field_names:
                         if data_row.has_key(field):
-                                row.append(data_row[field])
+                                if isinstance(data_row[field], unicode):
+                                        row.append(data_row[field].encode('ascii', 'replace'))
+                                else:
+                                        row.append(str(data_row[field]).encode('ascii','replace'))
                         else:
                                 row.append(None)
                 out.append(row)


### PR DESCRIPTION
Mdash and ndash's in referral notes were causing 500s for the legacy daily report.

Caused this error from reports.py line 80:
```
'ascii' codec can't encode character u'\u2013' in position 36: ordinal not in range(128) 
```
